### PR TITLE
Add Docker Compose setup and data loader script for Neo4j

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,13 +1,22 @@
-
 services:
+  webapp:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - NEO4J_URI=bolt://graphdb:7687
+      - NEO4J_USER=neo4j #you can change this to your username
+      - NEO4J_PASSWORD= Derek_password #you can change this to your password
+      - NEO4J_DATABASE=neo4j
+    depends_on:
+      - graphdb
+
   graphdb:
     image: neo4j:5.22.0
     ports:
       - "7474:7474"
       - "7687:7687"
     environment:
-      - NEO4J_AUTH=neo4j/password
-    volumes:
+      - NEO4J_AUTH=neo4j/Derek_password #you can change this to your username and password
       - ./data:/data
       - ./logs:/logs
-

--- a/load_data.py
+++ b/load_data.py
@@ -1,0 +1,45 @@
+import os
+import csv
+from neo4j import GraphDatabase
+from dotenv import load_dotenv
+
+class Neo4jLoader:
+    def __init__(self, uri, user, password, database):
+        self.driver = GraphDatabase.driver(uri, auth=(user, password))
+        self.database = database
+
+    def close(self):
+        self.driver.close()
+
+    def load_csv_to_neo4j(self, file_path, query):
+        with self.driver.session(database=self.database) as session:
+            with open(file_path, 'r') as csvfile:
+                reader = csv.DictReader(csvfile)
+                for row in reader:
+                    session.run(query, **row)
+                print(f"Loaded data from {file_path}")
+
+if __name__ == "__main__":
+    load_dotenv()
+    neo4j_uri = os.getenv("NEO4J_URI")
+    neo4j_user = os.getenv("NEO4J_USER")
+    neo4j_password = os.getenv("NEO4J_PASSWORD")
+    neo4j_database = os.getenv("NEO4J_DATABASE", "neo4j")
+
+    loader = Neo4jLoader(neo4j_uri, neo4j_user, neo4j_password, neo4j_database)
+
+    # Example: Load authors data
+    loader.load_csv_to_neo4j(
+        "data/books/authors.csv",
+        "CREATE (:Author {name: $name})"
+    )
+
+    # Example: Load books data
+    loader.load_csv_to_neo4j(
+        "data/books/books.csv",
+        "CREATE (:Book {title: $title, published: $published})"
+    )
+
+    # Add more data loading logic here
+
+    loader.close()


### PR DESCRIPTION
Hi Derek,

I've added a Docker Compose setup that runs the Python Webapp and Neo4j databases together. This setup should make it easier to develop and deploy the project. Additionally, I've included a `load_data.py` script to automate loading CSV data into Neo4j. The script handles data from the `books` dataset, but it can be easily extended to other datasets.

Let me know if any adjustments are needed. I am looking forward to your feedback!

Best regards,  
Achille
